### PR TITLE
Fix formatting issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <!-- lintgate:quality-badges:end -->
 
-> An MCP server for real-time code quality supervision — built entirely through vibe coding by a biochemist with no formal CS training.
+An MCP server for real-time code quality supervision — built entirely through vibe coding by a biochemist with no formal CS training.
 
-`--dangerously-skip-permissions`, minus the danger.
+> `--dangerously-skip-permissions`, minus the danger.
 
 A biochemist kept running into the same problem with AI-generated code. Not complex bugs — *discipline* bugs. The agent would act before it understood. It would hit an error, move on, and hit the same error twenty minutes later.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed blockquote formatting in README to improve readability and keep callouts consistent.
Removed the quote from the project tagline and added it to the “--dangerously-skip-permissions” callout.

<sup>Written for commit 650780a53a92d4b09c46fb3251cb1945c7a9e383. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

