### PR TITLE
Add workflow_dispatch to mutation testing

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -13,6 +13,7 @@ name: Mutation Testing
 on:
   push:
     branches: [main]
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'  # Weekly Monday 06:00 UTC
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger so mutation testing can be triggered manually via `gh workflow run mutation.yml`

## Test plan
- [ ] Merge, then run `gh workflow run mutation.yml --ref main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable manual runs of the Mutation Testing workflow by adding workflow_dispatch. You can now trigger it on demand, e.g., gh workflow run mutation.yml --ref main.

<sup>Written for commit 9819fb0e0b5fac01953b5f8f1a4aab8b8cc361c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

