### PR TITLE
Fix badge workflows: push to unprotected badges branch

### DIFF
--- a/.github/workflows/algebra-badges.yml
+++ b/.github/workflows/algebra-badges.yml
@@ -58,8 +58,13 @@ jobs:
           color: "blue"
           path: ".github/badges/properties.svg"
           
-      - name: Commit badges
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
-        with:
-          commit_message: "Update algebraic property badges"
-          file_pattern: ".github/badges/*.svg"
+      - name: Push badges to badges branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin badges:badges
+          git checkout badges -- .github/badges/ 2>/dev/null || true
+          git checkout -B badges
+          git add .github/badges/purity.svg .github/badges/properties.svg
+          git commit -m "Update algebra badges (Pure: ${{ env.PURE_FUNCTIONS }}, Properties: ${{ env.PROPERTIES_PROVEN }})" || echo "No changes"
+          git push origin badges

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,6 +65,7 @@ jobs:
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
+          gh-pages-branch: badges
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -151,9 +151,14 @@ jobs:
           color: "${{ steps.parse.outputs.color }}"
           path: ".github/badges/mutation.svg"
 
-      - name: Commit badge
+      - name: Push badge to badges branch
         if: steps.parse.outputs.skip != 'true'
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
-        with:
-          commit_message: "Update mutation score badge (${{ steps.parse.outputs.score }}% — ${{ steps.parse.outputs.killed }}/${{ steps.parse.outputs.total }} killed)"
-          file_pattern: ".github/badges/mutation.svg"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin badges:badges
+          git checkout badges -- .github/badges/ 2>/dev/null || true
+          git checkout -B badges
+          git add .github/badges/mutation.svg
+          git commit -m "Update mutation badge (${{ steps.parse.outputs.score }}% — ${{ steps.parse.outputs.killed }}/${{ steps.parse.outputs.total }} killed)" || echo "No changes"
+          git push origin badges

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=rohanvinaik_LintGate&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=rohanvinaik_LintGate)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=rohanvinaik_LintGate&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=rohanvinaik_LintGate)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=rohanvinaik_LintGate&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=rohanvinaik_LintGate)
-[![Mutation Score](https://raw.githubusercontent.com/rohanvinaik/LintGate/main/.github/badges/mutation.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/mutation.yml)
-[![Pure Functions](https://raw.githubusercontent.com/rohanvinaik/LintGate/main/.github/badges/purity.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
-[![Properties Proven](https://raw.githubusercontent.com/rohanvinaik/LintGate/main/.github/badges/properties.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
+[![Mutation Score](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/mutation.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/mutation.yml)
+[![Pure Functions](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/purity.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
+[![Properties Proven](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/properties.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
 [![Benchmark](https://github.com/rohanvinaik/LintGate/actions/workflows/benchmark.yml/badge.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/benchmark.yml)
 <!-- lintgate:quality-badges:end -->
 


### PR DESCRIPTION
## Summary
- Branch protection blocks workflows from auto-committing badge SVGs to main
- Create dedicated `badges` branch (unprotected) for badge storage
- Update algebra, mutation, and benchmark workflows to push there
- Update README badge URLs to reference `badges` branch

## Test plan
- [ ] Algebra Badges workflow pushes SVGs to badges branch
- [ ] Benchmark workflow stores results on badges branch
- [ ] README badges resolve from badges branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirected all badge workflows to push generated SVGs to an unprotected badges branch so branch protection no longer blocks updates. README badge URLs now point to the badges branch, keeping badges up to date.

- **Bug Fixes**
  - Algebra and mutation workflows now push badges to the badges branch using a scripted git push.
  - Benchmark workflow configured to publish to the badges branch via gh-pages-branch.
  - Updated README to load badges from badges instead of main.

<sup>Written for commit 4650834abcdb897facd5a51321ca3df1af48f9be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

