### PR TITLE
Fix badge push: save SVGs before branch switch

### DIFF
--- a/.github/workflows/algebra-badges.yml
+++ b/.github/workflows/algebra-badges.yml
@@ -60,11 +60,17 @@ jobs:
           
       - name: Push badges to badges branch
         run: |
+          # Save generated SVGs before switching branches
+          cp .github/badges/purity.svg /tmp/purity.svg
+          cp .github/badges/properties.svg /tmp/properties.svg
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin badges:badges
-          git checkout badges -- .github/badges/ 2>/dev/null || true
-          git checkout -B badges
+          git fetch origin badges
+          git checkout badges
+          mkdir -p .github/badges
+          cp /tmp/purity.svg .github/badges/purity.svg
+          cp /tmp/properties.svg .github/badges/properties.svg
           git add .github/badges/purity.svg .github/badges/properties.svg
           git commit -m "Update algebra badges (Pure: ${{ env.PURE_FUNCTIONS }}, Properties: ${{ env.PROPERTIES_PROVEN }})" || echo "No changes"
           git push origin badges

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -154,11 +154,14 @@ jobs:
       - name: Push badge to badges branch
         if: steps.parse.outputs.skip != 'true'
         run: |
+          cp .github/badges/mutation.svg /tmp/mutation.svg
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin badges:badges
-          git checkout badges -- .github/badges/ 2>/dev/null || true
-          git checkout -B badges
+          git fetch origin badges
+          git checkout badges
+          mkdir -p .github/badges
+          cp /tmp/mutation.svg .github/badges/mutation.svg
           git add .github/badges/mutation.svg
           git commit -m "Update mutation badge (${{ steps.parse.outputs.score }}% — ${{ steps.parse.outputs.killed }}/${{ steps.parse.outputs.total }} killed)" || echo "No changes"
           git push origin badges


### PR DESCRIPTION
## Summary
- Generated SVGs were lost when `git checkout badges` replaced the working tree
- Now saves SVGs to /tmp before switching branches, copies them back after checkout
- Fixes both algebra-badges and mutation workflows

## Test plan
- [ ] Algebra Badges workflow successfully pushes numerical SVGs to badges branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents generated badge SVGs from being lost when switching to the badges branch by saving them to /tmp and restoring after checkout. Ensures algebra and mutation workflows reliably push updated badges.

- **Bug Fixes**
  - Save SVGs to /tmp before branch switch; restore to .github/badges after checkout.
  - Use git fetch origin badges and git checkout badges, and create .github/badges if missing.

<sup>Written for commit 35070704ca7d2649b4b1a1af6aeab5b1a078e6cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

