### PR TITLE
Make workflows and badges repo-agnostic

### DIFF
--- a/.github/workflows/algebra-badges.yml
+++ b/.github/workflows/algebra-badges.yml
@@ -1,5 +1,9 @@
 name: Algebra Badges
 
+# Runs static analysis to count pure functions and algebraic properties
+# (commutative, associative, monotonic, bounded, idempotent) across the
+# codebase, then generates badges with the counts.
+
 on:
   push:
     branches: [ main ]
@@ -14,7 +18,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -24,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip==25.0.1
           pip install -e .[dev,algebra]
-          
+
       - name: Extract project metrics
         id: metrics
         run: |
@@ -33,19 +37,25 @@ jobs:
           from lintgate.linters.performance_checks.manifest import build_manifest
           py_files = sorted(glob.glob("lintgate/**/*.py", recursive=True))
           manifest = build_manifest(".", py_files)
+          total_funcs = manifest.pure_count + manifest.impure_count
           props_total = sum(manifest.property_distribution.values())
           with open(os.environ["GITHUB_ENV"], "a") as fh:
-              fh.write(f"PURE_FUNCTIONS={manifest.pure_count}\n")
-              fh.write(f"PROPERTIES_PROVEN={props_total}\n")
-          print(f"Pure: {manifest.pure_count}, Properties: {props_total}")
+              fh.write(f"PURE_COUNT={manifest.pure_count}\n")
+              fh.write(f"TOTAL_FUNCTIONS={total_funcs}\n")
+              fh.write(f"PROPERTIES_COUNT={props_total}\n")
+          dist = {k.value: v for k, v in manifest.property_distribution.items()}
+          print(f"Pure functions: {manifest.pure_count} / {total_funcs}")
+          print(f"Algebraic properties: {props_total}")
+          for prop, count in sorted(dist.items()):
+              print(f"  {prop}: {count}")
           PY
-          
+
       - name: Generate Purity Badge
         uses: emibcn/badge-action@4209421db54c8764d8932070ffd0f81715a629bf # v2.0.2
         id: badge_pure
         with:
-          label: "Pure Functions"
-          status: "${{ env.PURE_FUNCTIONS }}"
+          label: "Side-Effect-Free"
+          status: "${{ env.PURE_COUNT }} / ${{ env.TOTAL_FUNCTIONS }} functions"
           color: "success"
           path: ".github/badges/purity.svg"
 
@@ -53,14 +63,13 @@ jobs:
         uses: emibcn/badge-action@4209421db54c8764d8932070ffd0f81715a629bf # v2.0.2
         id: badge_prop
         with:
-          label: "Properties Proven"
-          status: "${{ env.PROPERTIES_PROVEN }}"
+          label: "Algebraic Properties"
+          status: "${{ env.PROPERTIES_COUNT }} detected"
           color: "blue"
           path: ".github/badges/properties.svg"
-          
+
       - name: Push badges to badges branch
         run: |
-          # Save generated SVGs before switching branches
           cp .github/badges/purity.svg /tmp/purity.svg
           cp .github/badges/properties.svg /tmp/properties.svg
 
@@ -72,5 +81,5 @@ jobs:
           cp /tmp/purity.svg .github/badges/purity.svg
           cp /tmp/properties.svg .github/badges/properties.svg
           git add .github/badges/purity.svg .github/badges/properties.svg
-          git commit -m "Update algebra badges (Pure: ${{ env.PURE_FUNCTIONS }}, Properties: ${{ env.PROPERTIES_PROVEN }})" || echo "No changes"
+          git commit -m "Update algebra badges (${{ env.PURE_COUNT }}/${{ env.TOTAL_FUNCTIONS }} pure, ${{ env.PROPERTIES_COUNT }} properties)" || echo "No changes"
           git push origin badges

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,7 @@
 name: Performance Benchmark
 
-# Measures wall-clock time of LintGate's hot paths:
-#   - Ruff lint on a single file (the PostToolUse:Edit critical path)
-#   - Agent report formatting (runs after every lint pass)
-#   - Purity analysis via AST (foundation of the algebraic pipeline)
-#   - Algebraic property classification (feeds Hypothesis/icontract)
-#   - Manifest building (orchestrates purity + properties across files)
-#
-# Alerts on >200% regression. Results tracked over time via
-# benchmark-action/github-action-benchmark.
+# Runs pytest-benchmark tests and tracks results over time.
+# Alerts on >200% regression via benchmark-action/github-action-benchmark.
 
 on:
   push:
@@ -42,12 +35,6 @@ jobs:
         id: run_benchmarks
         continue-on-error: true
         run: |
-          echo "## What this measures"
-          echo ""
-          echo "These benchmarks track the performance of LintGate's core"
-          echo "operations — the code that runs on every AI tool-use event."
-          echo "A regression here means slower feedback loops for supervised agents."
-          echo ""
           pytest tests/test_benchmarks.py --benchmark-only --benchmark-json output.json -v
           if [ ! -s output.json ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -60,7 +47,7 @@ jobs:
         if: steps.run_benchmarks.outputs.skip != 'true' && github.ref == 'refs/heads/main'
         uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1
         with:
-          name: LintGate Hot Path Benchmarks
+          name: Performance Benchmarks
           tool: 'pytest'
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,14 +1,8 @@
 name: Mutation Testing
 
-# Mutation testing injects small code changes (mutants) into LintGate's
-# architectural core and checks whether the test suite catches them.
-# A killed mutant = the tests detected the change. A survived mutant =
-# a gap in test effectiveness (not coverage — you can have 100% line
-# coverage and still miss mutations).
-#
-# Targets: controlplane/ + channels/ (the decision-making core).
-# Tool: mutmut (Python-native mutation testing).
-# Schedule: weekly + on push to main.
+# Injects small code changes (mutants) and checks whether the test suite
+# catches them. Killed = detected, survived = gap in test effectiveness.
+# Tool: mutmut. Schedule: weekly + on push to main.
 
 on:
   push:
@@ -70,12 +64,6 @@ jobs:
 
       - name: Run mutation testing
         run: |
-          echo "## What this measures"
-          echo ""
-          echo "Mutation testing checks whether the test suite detects small code"
-          echo "changes (e.g., flipping a comparison, removing a return statement)."
-          echo "High mutation score = tests catch real bugs, not just execute lines."
-          echo ""
           mutmut run \
             --paths-to-mutate="${{ steps.targets.outputs.paths }}" \
             --runner="python -m pytest tests/ -x -q --timeout=30 --tb=no" \

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# False positives: fake test tokens in test_behavior_compass.py
+d5a31347e7fff15dbbc8f31bd71c321afd26dfb0:tests/test_behavior_compass.py:curl-auth-header:66
+d0aef2ff1e07cb6002ad4e974b01fe0b3d8ea455:tests/test_behavior_compass.py:curl-auth-header:72
+d0aef2ff1e07cb6002ad4e974b01fe0b3d8ea455:tests/test_behavior_compass.py:stripe-access-token:72
+d5a31347e7fff15dbbc8f31bd71c321afd26dfb0:tests/test_behavior_compass.py:stripe-access-token:66

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=rohanvinaik_LintGate&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=rohanvinaik_LintGate)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=rohanvinaik_LintGate&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=rohanvinaik_LintGate)
 [![Mutation Score](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/mutation.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/mutation.yml)
-[![Pure Functions](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/purity.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
-[![Properties Proven](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/properties.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
+[![Side-Effect-Free](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/purity.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
+[![Algebraic Properties](https://raw.githubusercontent.com/rohanvinaik/LintGate/badges/.github/badges/properties.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/algebra-badges.yml)
 [![Benchmark](https://github.com/rohanvinaik/LintGate/actions/workflows/benchmark.yml/badge.svg)](https://github.com/rohanvinaik/LintGate/actions/workflows/benchmark.yml)
 <!-- lintgate:quality-badges:end -->
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,9 +1,8 @@
-"""Performance benchmarks for LintGate hot paths.
+"""Performance benchmarks.
 
-Measures wall-clock time of the core operations that run on every
-tool-use event (lint pipeline, report formatting) and the algebraic
-analysis pipeline (purity detection, property classification, manifest
-building). Regressions beyond 200% trigger a CI alert.
+Measures wall-clock time of core operations: lint pipeline, report
+formatting, purity analysis, property classification, and manifest
+building. Regressions beyond 200% trigger a CI alert.
 
 Requires: pip install pytest-benchmark
 Run locally: pytest tests/test_benchmarks.py --benchmark-only
@@ -76,7 +75,6 @@ def project_python_files():
 def test_bench_lint_single_file(benchmark, sample_file, tmp_path):
     """Lint a single Python file through the ruff linter.
 
-    This is the critical path — ruff runs on every PostToolUse:Edit event.
     Target: <500ms for a single file.
     """
     from lintgate.linters.ruff_linter import RuffLinter
@@ -88,10 +86,7 @@ def test_bench_lint_single_file(benchmark, sample_file, tmp_path):
 
 
 def test_bench_format_report(benchmark):
-    """Format a lint report with typical issue counts.
-
-    Runs after every lint pass to produce the agent-facing summary.
-    """
+    """Format a lint report with typical issue counts."""
     from lintgate.agent_reporter import format_report
     from lintgate.types import AggregatedResult, LintIssue
 
@@ -128,22 +123,14 @@ def test_bench_format_report(benchmark):
 # ---------------------------------------------------------------------------
 
 def test_bench_purity_analysis(benchmark, sample_tree):
-    """Detect pure vs impure functions via AST analysis.
-
-    The purity detector is the foundation of the algebraic pipeline —
-    its output feeds property classification and PERF011 checks.
-    """
+    """Detect pure vs impure functions via AST analysis."""
     from lintgate.linters.performance_checks.purity import analyze_purity
 
     benchmark(analyze_purity, sample_tree)
 
 
 def test_bench_property_classification(benchmark, sample_tree):
-    """Classify algebraic properties (commutative, associative, etc.).
-
-    Runs per-function after purity analysis to identify Hypothesis
-    test candidates and icontract decorator targets.
-    """
+    """Classify algebraic properties (commutative, associative, etc.)."""
     from lintgate.linters.performance_checks.properties import classify_properties
     from lintgate.linters.performance_checks.purity import analyze_purity
 
@@ -162,11 +149,7 @@ def test_bench_property_classification(benchmark, sample_tree):
 
 
 def test_bench_manifest_build(benchmark, tmp_path, sample_file):
-    """Build the full algebraic property manifest for a project.
-
-    Orchestrates purity + property classification across all files.
-    Runs in the Algebra Badges CI workflow and on-demand via MCP.
-    """
+    """Build the full algebraic property manifest for a project."""
     from lintgate.linters.performance_checks.manifest import build_manifest
 
     benchmark(build_manifest, str(tmp_path), [str(sample_file)])


### PR DESCRIPTION
## Summary
- Remove LintGate-specific language from CI workflow comments (benchmark, mutation, algebra-badges)
- Strip verbose echo statements explaining "what this measures" from workflow output
- Rename badge labels: "Pure Functions" → "Side-Effect-Free: N / M functions", "Properties Proven" → "Algebraic Properties: N detected"
- Simplify test_benchmarks.py docstrings to generic descriptions
- Add .gitleaksignore for false positive test fixture tokens

## Test plan
- [x] All 4,509 tests pass
- [x] Pre-push lint + secrets scan clean
- [ ] After merge, verify algebra-badges workflow generates correct badge text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CI workflows, badges, and benchmark docs repo-agnostic by removing LintGate-specific language and simplifying output. Badges now show “Side-Effect-Free N / M functions” and “Algebraic Properties N detected.”

- **Refactors**
  - Removed product-specific comments and “what this measures” echoes from benchmark and mutation workflows; renamed report to “Performance Benchmarks.”
  - Algebra badges: added TOTAL_FUNCTIONS and PROPERTIES_COUNT, switched to PURE_COUNT/TOTAL_FUNCTIONS, printed distribution, and updated commit message.
  - Renamed badge labels and updated README to match.
  - Simplified benchmark test docstrings to generic descriptions.
  - Added .gitleaksignore to ignore known fake test tokens in fixtures.

<sup>Written for commit 6bfd05b0f7c0b309634685daf720a07690b95952. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

