### PR TITLE
ship: enable GitHub auto-merge mode in ship_main

### DIFF
--- a/scripts/ship_main.py
+++ b/scripts/ship_main.py
@@ -369,13 +369,14 @@ def _watch_required_checks(
 
 
 def _merge_pr(repo_root: str, pr_number: int) -> None:
-    print(f"[ship] Merging PR #{pr_number} with squash + branch deletion")
+    print(f"[ship] Enabling GitHub auto-merge for PR #{pr_number} (squash + branch deletion)")
     _run(
         [
             "gh",
             "pr",
             "merge",
             str(pr_number),
+            "--auto",
             "--squash",
             "--delete-branch",
         ],

--- a/tests/test_ship_main.py
+++ b/tests/test_ship_main.py
@@ -323,7 +323,7 @@ def test_merge_pr(ship_main, monkeypatch):
         lambda cmd, **kwargs: calls.append((cmd, kwargs["cwd"])) or subprocess.CompletedProcess(cmd, 0),
     )
     ship_main._merge_pr("/repo", 42)
-    assert calls[0][0] == ["gh", "pr", "merge", "42", "--squash", "--delete-branch"]
+    assert calls[0][0] == ["gh", "pr", "merge", "42", "--auto", "--squash", "--delete-branch"]
 
 
 def test_prune_merged_local_branches(ship_main, monkeypatch):


### PR DESCRIPTION
Use GitHub-native auto-merge in ship pipeline by switching merge step to:\n\n\n\nThis preserves strict gate checks while aligning ship behavior with repository auto-merge semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable GitHub auto-merge in the ship pipeline by switching the merge step to gh pr merge --auto (with squash + branch deletion). This preserves required-check gates and matches repository auto-merge behavior.

<sup>Written for commit b1a81101414313ad2a2a34bf01ce3b873636a8cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

